### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ To use this buildpack specify the URI of the repository when pushing an IPython 
 The buildpack supports dependencies declaration using a `requirements.txt` file located in the root of the directory being pushed to Cloud Foundry.
 
 
-[Cloud Foundry]: http://www.cloudfoundry.com
-[IPython Notebook]: http://ipython.org/notebook.html
+[Cloud Foundry]: https://www.cloudfoundry.org
+[IPython Notebook]: https://ipython.org/notebook.html

--- a/compile
+++ b/compile
@@ -7,7 +7,7 @@ BASH=$(which bash)
 CONDA_HOME="$1/.conda"
 CONDA_BIN="$CONDA_HOME/bin"
 MINICONDA_CACHE="$CACHE/miniconda.sh"
-MINICONDA_URI='http://repo.continuum.io/miniconda/Miniconda3-2.0.3-MacOSX-x86_64.sh'
+MINICONDA_URI='https://repo.continuum.io/miniconda/Miniconda3-2.0.3-MacOSX-x86_64.sh'
 
 echo "-----> Preparing Python Environment..."
 if [ ! -e $MINICONDA_CACHE ] ; then


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://repo.continuum.io/miniconda/Miniconda3-2.0.3-MacOSX-x86_64.sh (301) with 1 occurrences migrated to:  
  https://repo.continuum.io/miniconda/Miniconda3-2.0.3-MacOSX-x86_64.sh ([https](https://repo.continuum.io/miniconda/Miniconda3-2.0.3-MacOSX-x86_64.sh) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://ipython.org/notebook.html with 1 occurrences migrated to:  
  https://ipython.org/notebook.html ([https](https://ipython.org/notebook.html) result 200).
* http://www.cloudfoundry.com (301) with 1 occurrences migrated to:  
  https://www.cloudfoundry.org ([https](https://www.cloudfoundry.com) result 200).