### PR TITLE
Update link to match new(?) organisation name

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The `ipython-notebook-buildpack` is a [Cloud Foundry][] buildpack for exposing [
 ## Usage
 To use this buildpack specify the URI of the repository when pushing an IPython Notebook file (or directory of files) to Cloud Foundry.
 
-    cf push --buildpack https://github.com/gopivotal/ipython-notebook-buildpack.git
+    cf push --buildpack https://github.com/pivotalsoftware/ipython-notebook-buildpack.git
 
 ## Notebook Dependencies
 The buildpack supports dependencies declaration using a `requirements.txt` file located in the root of the directory being pushed to Cloud Foundry.


### PR DESCRIPTION
It looks like this repo has moved in GitHub from `gopivotal` to `pivotalsoftware`. The README's still got the old link.

I think this probably redirects fine, so this is just a cosmetic fix.